### PR TITLE
Add gitleaks secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,28 @@
+name: Gitleaks
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+  workflow_call:
+
+concurrency: gitleaks-${{ github.ref }}
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,12 @@ repos:
       - id: debug-statements
         files: ^src/.*\.py$
 
+  # Security scanning
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      - id: gitleaks
+
   # Validate packaging metadata early
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.24.1


### PR DESCRIPTION
## Summary
- Add a gitleaks pre-commit hook (`v8.24.2`) for local secret scanning
- Add a Gitleaks CI workflow using the official `gitleaks/gitleaks-action@v2`

## Details
- The workflow checks out full history (`fetch-depth: 0`) so gitleaks can scan all commits, and passes `GITHUB_TOKEN` so the action can post PR summaries.
- Triggers on push/PR to `master`, plus `workflow_dispatch` and `workflow_call`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)